### PR TITLE
difference image option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ To see all the options, use the `--help` argument to see the full usage informat
                   [--step STEP] [--fps FPS] [--binning BINNING] [--dpi DPI]
                   [--stretch STRETCH] [--min_cut MIN_CUT] [--max_cut MAX_CUT]
                   [--min_percent %] [--max_percent %] [--cmap CMAP] [--flags]
-                  [--raw | --background | --cosmic]
+                  [--label LABEL] [--difference] [--raw | --background | --cosmic]
                   [--ut | --jd | --mjd | --bkjd | --cadence]
                   tpf_filename [tpf_filename ...]
 
@@ -122,6 +122,8 @@ To see all the options, use the `--help` argument to see the full usage informat
       --max_percent %    maximum cut percentile (default: 95)
       --cmap CMAP        matplotlib color map name (default: gray)
       --flags            show the quality flags
+      --label LABEL      label to show in the bottom left corner (default: objectname)
+      --difference       show the median-subtracted difference image
       --raw              show the uncalibrated pixel counts ('RAW_CNTS')
       --background       show the background flux ('FLUX_BKG')
       --cosmic           show the cosmic rays ('COSMIC_RAYS')


### PR DESCRIPTION
I've added an option to animate difference images produced by subtracting the median image from each frame. Merge if interested.

I tested this with the call `k2flix --bkjd --start 2496.25 --stop 2497.5 --step 20 --fps 12 --difference --stretch linear tess2021258175143-s0043-0000000415339071-0214-s_tp.fits` on the data set available at https://archive.stsci.edu/doi/resolve/resolve.html?doi=10.17909/02qr-hh98